### PR TITLE
Quick&Dirty: Wait for lock to be released

### DIFF
--- a/esy-build-package/Build.re
+++ b/esy-build-package/Build.re
@@ -263,7 +263,7 @@ let withLock = (lockPath: Path.t, f) => {
     UnixLabels.(lockf(fd, ~mode=F_ULOCK, ~len=0));
     Unix.close(fd);
   };
-  UnixLabels.(lockf(fd, ~mode=F_TLOCK, ~len=0));
+  UnixLabels.(lockf(fd, ~mode=F_LOCK, ~len=0));
   let res =
     try({
       let res = f();


### PR DESCRIPTION
This is a quick&dirty fix for #esy/esy/630

Might have to be extended for a timeout for better use.